### PR TITLE
removes double-application of value of cash

### DIFF
--- a/code/modules/cargo/exports/f13Cash.dm
+++ b/code/modules/cargo/exports/f13Cash.dm
@@ -1,50 +1,14 @@
 /datum/export/f13Cash
-	k_elasticity = 0
-
-/datum/export/f13Cash
 	cost = 1
 	k_elasticity = 0
 	unit_name = "cap"
 	export_types = list(/obj/item/stack/f13Cash)
 
-/datum/export/large/f13Cash/total_printout(datum/export_report/ex, notes = TRUE)
+/datum/export/f13Cash/get_amount(obj/O)
+	var/obj/item/stack/f13Cash/caps_entered = O
+	return ..() * caps_entered.get_item_credit_value()
+
+/datum/export/f13Cash/total_printout(datum/export_report/ex, notes = TRUE)
 	. = ..()
 	if(. && notes)
 		. += " Your deposit is completed."
-
-/datum/export/f13Cash/get_amount(obj/O)
-    if(!isitem(O))
-        return 0
-    var/obj/item/I = O
-    if(!istype(I, /obj/item/stack/f13Cash))
-        return 0
-
-    var/obj/item/stack/f13Cash/c = I
-    var/amount = c.get_item_credit_value()
-
-    return amount
-
-/datum/export/f13Cash/caps
-	cost = 1
-	unit_name = "cap"
-	export_types = list(/obj/item/stack/f13Cash/caps)
-	exclude_types = list()
-
-/datum/export/f13Cash/ncr
-	cost = 0.4
-	unit_name = "dollar"
-	export_types = list(/obj/item/stack/f13Cash/ncr)
-	exclude_types = list()
-
-/datum/export/f13Cash/denarius
-	cost = 4
-	unit_name = "denarius"
-	export_types = list(/obj/item/stack/f13Cash/denarius)
-	exclude_types = list()
-
-/datum/export/f13Cash/aureus
-	cost = 100
-	unit_name = "aureus"
-	export_types = list(/obj/item/stack/f13Cash/aureus)
-	exclude_types = list()
-

--- a/code/modules/fallout/obj/stack/f13Cash.dm
+++ b/code/modules/fallout/obj/stack/f13Cash.dm
@@ -209,7 +209,7 @@
 	singular_name = "Denari" // -us or -i
 	icon = 'icons/obj/economy.dmi'
 	icon_state = "denarius"
-	flavor_desc =	"The inscriptions are in Latin,\n\
+	flavor_desc = "The inscriptions are in Latin,\n\
 		'Caesar Dictator' on the front and\n\
 		'Magnum Chasma' on the back."
 	value = CASH_DEN * CASH_CAP
@@ -248,9 +248,9 @@
 	singular_name = "Aure"// -us or -i
 	icon = 'icons/obj/economy.dmi'
 	icon_state = "aureus"
-	flavor_desc = 	"The inscriptions are in Latin,\n\
-					'Aeternit Imperi' on the front and\n\
-					'Pax Per Bellum' on the back."
+	flavor_desc =  "The inscriptions are in Latin,\n\
+		'Aeternit Imperi' on the front and\n\
+		'Pax Per Bellum' on the back."
 	value = CASH_AUR * CASH_CAP
 	merge_type = /obj/item/stack/f13Cash/aureus
 


### PR DESCRIPTION
removes the export cost being doubled and makes the printout message show up.